### PR TITLE
Remove Python 3.9 from pytest CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

- Removes Python 3.9 from the `python-version` matrix in `.github/workflows/tests.yml`
- CI now tests against Python 3.10, 3.11, and 3.12 only

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xqbk5Vrt77o85DidMip4R5)_